### PR TITLE
Remove fields from Layer Panel

### DIFF
--- a/src/components/map/map-control.js
+++ b/src/components/map/map-control.js
@@ -66,11 +66,11 @@ function MapControlFactory(
   LocalePanel
 ) {
   const DEFAULT_ACTIONS = [
-    // SplitMapButton,
-    // LayerSelectorPanel,
-    // Toggle3dButton,
-    // MapDrawPanel,
-    // LocalePanel,
+    SplitMapButton,
+    LayerSelectorPanel,
+    Toggle3dButton,
+    MapDrawPanel,
+    LocalePanel,
     MapLegendPanel
   ];
 

--- a/src/components/side-panel/layer-panel/layer-configurator.js
+++ b/src/components/side-panel/layer-panel/layer-configurator.js
@@ -548,15 +548,15 @@ export default function LayerConfiguratorFactory(
             </ConfigGroupCollapsibleContent>
           </LayerConfigGroup>
 
-          {/* elevation scale */}
-          {layer.visConfigSettings.elevationScale ? (
+          {/* Didable elevation scale */}
+          {/* {layer.visConfigSettings.elevationScale ? (
             <LayerConfigGroup label="layerVisConfigs.elevationScale" collapsible>
               <VisConfigSlider
                 {...layer.visConfigSettings.elevationScale}
                 {...visConfiguratorProps}
               />
             </LayerConfigGroup>
-          ) : null}
+          ) : null} */}
         </StyledLayerVisualConfigurator>
       );
     }
@@ -638,7 +638,7 @@ export default function LayerConfiguratorFactory(
     }) {
       const {
         meta: {featureTypes = {}},
-        config: {visConfig}
+        config: {}
       } = layer;
 
       return (
@@ -722,8 +722,8 @@ export default function LayerConfiguratorFactory(
             </ConfigGroupCollapsibleContent>
           </LayerConfigGroup>
 
-          {/* Elevation */}
-          {featureTypes.polygon ? (
+          {/* Disable Elevation Feature */}
+          {/* {featureTypes.polygon ? (
             <LayerConfigGroup
               {...visConfiguratorProps}
               {...layer.visConfigSettings.enable3d}
@@ -747,7 +747,7 @@ export default function LayerConfiguratorFactory(
                 <VisConfigSwitch {...visConfiguratorProps} {...layer.visConfigSettings.wireframe} />
               </ConfigGroupCollapsibleContent>
             </LayerConfigGroup>
-          ) : null}
+          ) : null} */}
 
           {/* Radius */}
           {featureTypes.point ? (
@@ -935,9 +935,7 @@ export default function LayerConfiguratorFactory(
 
     render() {
       const {layer, datasets, updateLayerConfig, layerTypeOptions, updateLayerType} = this.props;
-      const {fields = [], fieldPairs = undefined} = layer.config.dataId
-        ? datasets[layer.config.dataId]
-        : {};
+      const {fields = []} = layer.config.dataId ? datasets[layer.config.dataId] : {};
       const {config} = layer;
 
       const visConfiguratorProps = getVisConfiguratorProps(this.props);
@@ -973,7 +971,8 @@ export default function LayerConfiguratorFactory(
               assignColumn={layer.assignColumn.bind(layer)}
               columnLabels={layer.columnLabels}
               fields={fields}
-              fieldPairs={fieldPairs}
+              /* Disable "Suggested Field" option in dropdowns */
+              // fieldPairs={fieldPairs}
               updateLayerConfig={updateLayerConfig}
               updateLayerType={this.props.updateLayerType}
             />

--- a/src/components/side-panel/map-manager.js
+++ b/src/components/side-panel/map-manager.js
@@ -29,11 +29,15 @@ import PropTypes from 'prop-types';
 import {injectIntl} from 'react-intl';
 import MapStyleSelectorFactory from 'components/side-panel/map-style-panel/map-style-selector';
 import MapLayerLegendFactory from './map-style-panel/map-layer-legend';
-// import LayerGroupSelectorFactory from 'components/side-panel/map-style-panel/map-layer-selector';
+import LayerGroupSelectorFactory from 'components/side-panel/map-style-panel/map-layer-selector';
 
-MapManagerFactory.deps = [MapStyleSelectorFactory, MapLayerLegendFactory];
+MapManagerFactory.deps = [
+  MapStyleSelectorFactory,
+  MapLayerLegendFactory,
+  LayerGroupSelectorFactory
+];
 
-function MapManagerFactory(MapStyleSelector, MapLayerLegend) {
+function MapManagerFactory(MapStyleSelector, MapLayerLegend, LayerGroupSelector) {
   class MapManager extends Component {
     static propTypes = {
       mapStyle: PropTypes.object.isRequired,
@@ -60,11 +64,11 @@ function MapManagerFactory(MapStyleSelector, MapLayerLegend) {
     };
 
     render() {
-      const {mapStyles, styleType} = this.props.mapStyle;
+      const {mapStyle, mapStyleActions} = this.props;
+      const {mapStyles, styleType} = mapStyle;
       const mapLegends = mapStyles[styleType].legends || [];
-      // const {mapStyle, mapStyleActions} = this.props;
-      // const currentStyle = mapStyle.mapStyles[mapStyle.styleType] || {};
-      // const editableLayers = (currentStyle.layerGroups || []).map(lg => lg.slug);
+      const currentStyle = mapStyles[mapStyle.styleType] || {};
+      const editableLayers = (currentStyle.layerGroups || []).map(lg => lg.slug);
       // const hasBuildingLayer = mapStyle.visibleLayerGroups['3d building'];
       // const colorSetSelector = createSelector(
       //   this.buildingColorSelector,
@@ -90,8 +94,6 @@ function MapManagerFactory(MapStyleSelector, MapLayerLegend) {
               onChange={this._selectStyle}
               toggleActive={this._toggleSelecting}
             />
-            {mapLegends.length > 0 && <MapLayerLegend legendList={mapLegends} />}
-            {/* Enable Custom Map Manager
             {editableLayers.length ? (
               <LayerGroupSelector
                 layers={mapStyle.visibleLayerGroups}
@@ -100,6 +102,8 @@ function MapManagerFactory(MapStyleSelector, MapLayerLegend) {
                 onChange={mapStyleActions.mapConfigChange}
               />
             ) : null}
+            {mapLegends.length > 0 && <MapLayerLegend legendList={mapLegends} />}
+            {/* Enable Custom Map Manager
             <SidePanelSection>
               <ColorSelector colorSets={colorSets} disabled={!hasBuildingLayer} />
             </SidePanelSection>

--- a/src/components/side-panel/map-style-panel/map-layer-selector.js
+++ b/src/components/side-panel/map-style-panel/map-layer-selector.js
@@ -25,7 +25,6 @@ import {EyeSeen, EyeUnseen, Upload} from 'components/common/icons';
 
 import {
   PanelLabel,
-  PanelContent,
   PanelLabelBold,
   PanelLabelWrapper,
   CenterFlexbox
@@ -35,6 +34,11 @@ import {camelize} from 'utils/utils';
 
 const StyledInteractionPanel = styled.div`
   padding-bottom: 12px;
+`;
+
+const StyledLayerPanel = styled.div`
+  padding: 12px;
+  background-color: ${props => props.theme.panelBackground};
 `;
 
 const StyledLayerGroupItem = styled.div`
@@ -75,7 +79,7 @@ function LayerGroupSelectorFactory(PanelHeaderAction) {
           <FormattedMessage id={'mapLayers.title'} />
         </PanelLabel>
       </div>
-      <PanelContent className="map-style__layer-group">
+      <StyledLayerPanel className="map-style__layer-group">
         {editableLayers.map(slug => (
           <StyledLayerGroupItem className="layer-group__select" key={slug}>
             <PanelLabelWrapper>
@@ -96,7 +100,7 @@ function LayerGroupSelectorFactory(PanelHeaderAction) {
                 flush
               />
               <LayerLabel active={layers[slug]}>
-                <FormattedMessage id={`mapLayers.${camelize(slug)}`} />
+                <FormattedMessage id={`mapLayers.${camelize(slug)}`} defaultMessage={slug} />
               </LayerLabel>
             </PanelLabelWrapper>
             <CenterFlexbox className="layer-group__bring-top">
@@ -118,7 +122,7 @@ function LayerGroupSelectorFactory(PanelHeaderAction) {
             </CenterFlexbox>
           </StyledLayerGroupItem>
         ))}
-      </PanelContent>
+      </StyledLayerPanel>
     </StyledInteractionPanel>
   );
 


### PR DESCRIPTION
### About

When selecting any input field in Layers panel a dropdown comes up with "Suggested field" option. This option should be removed.

When selecting layer type Line, the field "Elevation Scale" shows up. This field should be removed.

### Before

![image](https://user-images.githubusercontent.com/23040954/155274006-5fd57847-f628-4f8d-9310-dcb057dec415.png)

---

![image](https://user-images.githubusercontent.com/23040954/155274030-6b3f4c52-2268-45df-a1cd-e96493e11e7f.png)

### After

<img width="287" alt="image" src="https://user-images.githubusercontent.com/23040954/155274117-d4462947-3123-4405-8f6b-03d9f18f56ff.png">

---

<img width="299" alt="image" src="https://user-images.githubusercontent.com/23040954/155274192-bd978c15-ccf2-4089-82c2-d655b1ca50da.png">
