### PR TITLE
Feat: Color based on Hexadecimal values

### DIFF
--- a/examples/custom-map-style/src/store.js
+++ b/examples/custom-map-style/src/store.js
@@ -62,6 +62,9 @@ const reducers = combineReducers({
 });
 
 const middlewares = enhanceReduxMiddleware([]);
-const enhancers = [applyMiddleware(...middlewares)];
+const enhancers = [
+  applyMiddleware(...middlewares)
+  // window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+];
 
 export default createStore(reducers, {}, compose(...enhancers));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "kepler.gl",
   "author": "Shan He <shan@uber.com>",
-  "version": "2.5.6",
+  "contributors": [
+    "Cesar Sanchez <cesar.sanchezibr@gmail.com>"
+  ],
+  "version": "2.5.7",
   "description": "kepler.gl is a webgl based application to visualize large scale location data in the browser",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/components/side-panel/layer-panel/layer-configurator.js
+++ b/src/components/side-panel/layer-panel/layer-configurator.js
@@ -149,6 +149,7 @@ export default function LayerConfiguratorFactory(
             <ConfigGroupCollapsibleContent>
               <ChannelByValueSelector
                 channel={layer.visualChannels.color}
+                description="layerConfiguration.color"
                 {...layerChannelConfigProps}
               />
               <VisConfigSlider {...layer.visConfigSettings.opacity} {...visConfiguratorProps} />

--- a/src/constants/default-settings.d.ts
+++ b/src/constants/default-settings.d.ts
@@ -7,6 +7,7 @@ export const ALL_FIELD_TYPES: {
   integer: 'integer';
   real: 'real';
   string: 'string';
+  hexstring: 'hexstring';
   timestamp: 'timestamp';
   point: 'point';
 };
@@ -42,6 +43,7 @@ export type SCALE_TYPES_DEF = {
   sqrt: 'sqrt',
   log: 'log';
   point: 'point';
+  hexcolor: 'hexcolor';
 }
 
 export const SCALE_TYPES: SCALE_TYPES_DEF;

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -44,6 +44,7 @@ import {
 import {getHTMLMapModeTileUrl} from 'utils/utils';
 import {TOOLTIP_FORMAT_TYPES} from './tooltip';
 import {LAYER_TYPES} from 'layers/types';
+import {hexColorScale} from 'utils/color-utils';
 
 export const ACTION_PREFIX = '@@kepler.gl/';
 export const CLOUDFRONT = 'https://d1a3f4spazzrp4.cloudfront.net/kepler.gl';
@@ -312,7 +313,8 @@ export const SCALE_TYPES = keyMirror({
   log: null,
 
   // ordinal domain to linear range
-  point: null
+  point: null,
+  hexcolor: null
 });
 
 export const SCALE_FUNC = {
@@ -322,7 +324,8 @@ export const SCALE_FUNC = {
   [SCALE_TYPES.ordinal]: scaleOrdinal,
   [SCALE_TYPES.sqrt]: scaleSqrt,
   [SCALE_TYPES.log]: scaleLog,
-  [SCALE_TYPES.point]: scalePoint
+  [SCALE_TYPES.point]: scalePoint,
+  [SCALE_TYPES.hexcolor]: hexColorScale
 };
 
 export const ALL_FIELD_TYPES = keyMirror({
@@ -332,6 +335,7 @@ export const ALL_FIELD_TYPES = keyMirror({
   integer: null,
   real: null,
   string: null,
+  hexstring: null,
   timestamp: null,
   point: null
 });
@@ -384,6 +388,7 @@ export const TABLE_OPTION_LIST = [
 const ORANGE = '248, 194, 28';
 const PINK = '231, 189, 194';
 const PURPLE = '160, 106, 206';
+const PURPLE2 = '148, 8, 150';
 const BLUE = '140, 210, 205';
 const BLUE2 = '106, 160, 206';
 const BLUE3 = '0, 172, 237';
@@ -414,6 +419,10 @@ export const FILED_TYPE_DISPLAY = {
   [ALL_FIELD_TYPES.string]: {
     label: 'string',
     color: BLUE
+  },
+  [ALL_FIELD_TYPES.hexstring]: {
+    label: 'hex',
+    color: PURPLE2
   },
   [ALL_FIELD_TYPES.timestamp]: {
     label: 'time',
@@ -482,6 +491,12 @@ export const linearFieldAggrScaleFunctions = {
   }
 };
 
+export const hexColorFieldScaleFunctions = {
+  [CHANNEL_SCALES.color]: [SCALE_TYPES.hexcolor],
+  [CHANNEL_SCALES.radius]: [SCALE_TYPES.point],
+  [CHANNEL_SCALES.size]: [SCALE_TYPES.point]
+};
+
 export const ordinalFieldScaleFunctions = {
   [CHANNEL_SCALES.color]: [SCALE_TYPES.ordinal],
   [CHANNEL_SCALES.radius]: [SCALE_TYPES.point],
@@ -531,6 +546,17 @@ export const FIELD_OPTS = {
     scale: {
       ...ordinalFieldScaleFunctions,
       ...ordinalFieldAggrScaleFunctions
+    },
+    format: {
+      legend: d => d,
+      tooltip: []
+    }
+  },
+  hexstring: {
+    type: 'numerical',
+    scale: {
+      ...hexColorFieldScaleFunctions,
+      ...notSupportAggrOpts
     },
     format: {
       legend: d => d,
@@ -634,7 +660,7 @@ export const DEFAULT_LAYER_COLOR = {
 // let user pass in default tooltip fields
 export const DEFAULT_TOOLTIP_FIELDS = [];
 
-export const NO_VALUE_COLOR = [0, 0, 0, 0];
+export const NO_VALUE_COLOR = [0, 0, 0, 255];
 
 export const LAYER_BLENDINGS = {
   additive: {

--- a/src/localization/translations/en.js
+++ b/src/localization/translations/en.js
@@ -174,6 +174,8 @@ export default {
   },
   layerConfiguration: {
     defaultDescription: 'Calculate {property} based on selected field',
+    color: `Calculate color based on selected field. If the field is hexadecimal 
+    it will use its hex values for the color. Defaults to black when no color is found`,
     howTo: 'How to'
   },
   filterManager: {

--- a/src/processors/data-processor.js
+++ b/src/processors/data-processor.js
@@ -291,7 +291,8 @@ export function getFieldsFromData(data, fieldOrder) {
     data,
     [
       {regex: /.*geojson|all_points/g, dataType: 'GEOMETRY'},
-      {regex: /.*census/g, dataType: 'STRING'}
+      {regex: /.*census/g, dataType: 'STRING'},
+      {regex: /hex_*|color|colour/g, dataType: 'HEXSTRING'}
     ],
     {ignoredDataTypes: IGNORE_DATA_TYPES}
   );
@@ -404,6 +405,8 @@ export function analyzerTypeToFieldType(aType) {
     case STRING:
     case ZIPCODE:
       return ALL_FIELD_TYPES.string;
+    case 'HEXSTRING':
+      return ALL_FIELD_TYPES.hexstring;
     default:
       globalConsole.warn(`Unsupported analyzer type: ${aType}`);
       return ALL_FIELD_TYPES.string;

--- a/src/utils/color-utils.d.ts
+++ b/src/utils/color-utils.d.ts
@@ -7,3 +7,4 @@ export const rgbToHex: (colors: [number, number, number]) => string;
 
 export const getColorGroupByName: (ColorRange) => ColorRange;
 export function isRgbColor(color: unknown): color is RGBColor;
+export function hexColorScale(): () => Function;

--- a/src/utils/color-utils.js
+++ b/src/utils/color-utils.js
@@ -121,3 +121,29 @@ export function isRgbColor(color) {
   }
   return false;
 }
+
+export function hexColorScale() {
+  function scale(value = '') {
+    return hexToRgb(value);
+  }
+
+  scale._domain = [];
+  scale.domain = d => {
+    if (Array.isArray(d)) {
+      scale._domain = d;
+      return scale;
+    }
+    return scale._domain;
+  };
+
+  scale._range = [];
+  scale.range = r => {
+    if (Array.isArray(r)) {
+      scale._range = r;
+      return scale;
+    }
+    return scale._range;
+  };
+
+  return scale;
+}

--- a/src/utils/table-utils/kepler-table.js
+++ b/src/utils/table-utils/kepler-table.js
@@ -332,6 +332,7 @@ class KeplerTable {
     switch (scaleType) {
       case SCALE_TYPES.ordinal:
       case SCALE_TYPES.point:
+      case SCALE_TYPES.hexcolor:
         // do not recalculate ordinal domain based on filtered data
         // don't need to update ordinal domain every time
         return getOrdinalDomain(dataContainer, valueAccessor);


### PR DESCRIPTION
# About

Now it's possible to select an hexadecimal column from the dataset and use those hexadecimal values as color fill for each Point in the layer.

# Demo

### Info updated

<img width="337" alt="Screenshot 2022-03-14 at 16 56 49" src="https://user-images.githubusercontent.com/23040954/158311148-2dbe4280-d876-4277-951c-c7717514eec1.png">

### Chose hexadecimal column

<img width="371" alt="Screenshot 2022-03-14 at 16 57 00" src="https://user-images.githubusercontent.com/23040954/158311812-daa624c2-93d6-441f-84ee-d2962a9ef8d4.png">

### Kepler uses the hex values to color

<img width="869" alt="Screenshot 2022-03-14 at 16 57 15" src="https://user-images.githubusercontent.com/23040954/158311863-4e68c04e-aae7-46fc-a3b3-60be67c37cc7.png">

