### PR TITLE
Add Default Field Type

### DIFF
--- a/src/processors/data-processor.js
+++ b/src/processors/data-processor.js
@@ -298,12 +298,16 @@ export function getFieldsFromData(data, fieldOrder) {
   );
 
   const {fieldByIndex} = renameDuplicateFields(fieldOrder);
+  const defaultFieldMeta = {
+    type: AnalyzerDATA_TYPES.STRING,
+    format: ''
+  };
 
   const result = fieldOrder.map((field, index) => {
     const name = fieldByIndex[index];
 
     const fieldMeta = metadata.find(m => m.key === field);
-    const {type, format} = fieldMeta || {};
+    const {type, format} = fieldMeta || defaultFieldMeta;
 
     return {
       name,


### PR DESCRIPTION
# About

There's a problem determining the `AnalyzerDATA_TYPE` for a column which has not values in the dataset (empty column).
Because there are no values to analyze the resulting `type` is undefined. 

# Solution

Define a default `AnalyzerDATA_TYPE` for this cases.
